### PR TITLE
Fixes basepath resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,12 +55,12 @@ function include(file, text, includeRegExp, prefix, basepath, filters) {
       basepath = path.dirname(file.path);
       break;
     case '@root':
-      basepath = '';
+      basepath = process.cwd();
       break;
     default:
       break;
   }
-  basepath = path.resolve(__dirname, basepath);
+  basepath = path.resolve(process.cwd(), basepath);
 
   while (matches) {
     var match = matches[0],


### PR DESCRIPTION
Instead of using __dirname for path resolution (which points to the root dir of the module), uses process.cwd() in order to resolve paths from the gulp execution standpoint as it should be expected.
