### PR TITLE
Handle UTF-8 with BOM (strip BOM)

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function include(file, text, includeRegExp, prefix, basepath, filters) {
     includeContent = includeContent.toString('utf-8').replace(/\uFEFF/, '');
 
     // need to double each `$` to escape it in the `replace` function
-    includeContent = String(includeContent).replace(/\$/gi, '$$$$');
+    includeContent = includeContent.replace(/\$/gi, '$$$$');
 
     // apply filters on include content
     if (typeof filters === 'object') {


### PR DESCRIPTION
See commits. When BOM is not removed, this results in extra white-space in the HTML-page after including a HTML-partial with @@include.
