### PR TITLE
Fix aggressive regex matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
     context = {};
   }
 
-  var includeRegExp = new RegExp(prefix + 'include\\s*\\([^)]*["\'](.*?)["\'](,\\s*({[\\s\\S]*?})){0,1}\\s*\\)+');
+  var includeRegExp = new RegExp(prefix + 'include\\s*\\([^)"\']*["\']([^"\']*)["\'](,\\s*({[\\s\\S]*?})){0,1}\\s*\\)+');
 
   function fileInclude(file) {
     var self = this;

--- a/test/fixtures/index-04.js
+++ b/test/fixtures/index-04.js
@@ -1,0 +1,7 @@
+(function(okanjo) {
+
+    okanjo.mvc.registerCss("main", "@@include(jsStringEscape('./test/fixtures/view.html'))", { id: 'okanjo-test-main' });
+
+    okanjo.mvc.registerCss("main", '@@include(jsStringEscape("test/fixtures/var.js", { "name": "haoxin", "age": 12345 }))', { id: 'okanjo-test-main' });
+
+})(okanjo);

--- a/test/fixtures/result.js
+++ b/test/fixtures/result.js
@@ -1,0 +1,7 @@
+(function(okanjo) {
+
+    okanjo.mvc.registerCss("main", "<h1>view</h1>", { id: 'okanjo-test-main' });
+
+    okanjo.mvc.registerCss("main", '<label>haoxin</label><label>12345</label>', { id: 'okanjo-test-main' });
+
+})(okanjo);

--- a/test/fixtures/var.js
+++ b/test/fixtures/var.js
@@ -1,0 +1,1 @@
+<label>@@name</label><label>@@age</label>

--- a/test/index.js
+++ b/test/index.js
@@ -366,9 +366,6 @@ describe('## gulp-file-include', function() {
       stream.on('data', function(newFile) {
         should.exist(newFile);
         should.exist(newFile.contents);
-
-        console.log(newFile.contents + "");
-
         String(newFile.contents).should.equal(resultJS);
         done();
       });

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var fileIncludePlugin = require('..'),
 
 describe('## gulp-file-include', function() {
   var result = fs.readFileSync('test/fixtures/result.html', 'utf8');
+  var resultJS = fs.readFileSync('test/fixtures/result.js', 'utf8');
   var resultSamePrefix = fs.readFileSync('test/fixtures/sameprefix-result.html', 'utf8');
 
   describe('# default', function() {
@@ -350,4 +351,30 @@ describe('## gulp-file-include', function() {
       stream.end();
     });
   });
+
+  describe('# aggressive regex', function() {
+    it('stream - basepath: @root', function(done) {
+      var file = new gutil.File({
+        path: 'test/fixtures/index-04.js',
+        contents: fs.createReadStream('test/fixtures/index-04.js')
+      });
+
+      var stream = fileIncludePlugin({
+        prefix: '@@',
+        basepath: '@root'
+      });
+      stream.on('data', function(newFile) {
+        should.exist(newFile);
+        should.exist(newFile.contents);
+
+        console.log(newFile.contents + "");
+
+        String(newFile.contents).should.equal(resultJS);
+        done();
+      });
+
+      stream.write(file);
+      stream.end();
+    });
+  })
 });


### PR DESCRIPTION
Fixes the include regex pattern `includeRegExp` being too aggressive, and would match the last instance of `, {`, which, in a JavaScript context, can be problematic.


#### Live Examples:
* **Previous (too aggressive)**: http://www.regexr.com/3aj2n
* **Fixed**: http://www.regexr.com/3aj2k

#### Fixes the Following Error
```
stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
Error: ENOENT, no such file or directory '/Users/kfitzgerald/Repositories/my-repo/))'
```

Notice the file name, which is: `))`

Also included in this PR is a unit test, to help make sure that the pattern continues to cover this scenario.