### PR TITLE
Support for valid json syntax and gulp-file-include.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,20 +8,22 @@ var concat = require('concat-stream'),
   fs = require('fs');
 
 module.exports = function(options) {
-  var prefix, basepath, filters, context;
+  var prefix, suffix, basepath, filters, context;
 
   if (typeof options === 'object') {
     basepath = options.basepath || '@file';
     prefix = options.prefix || '@@';
+    suffix = options.suffix || '';
     context = options.context || {};
     filters = options.filters;
   } else {
     prefix = options || '@@';
+    suffix = '';
     basepath = '@file';
     context = {};
   }
 
-  var includeRegExp = new RegExp(prefix + 'include\\s*\\([^)"\']*["\']([^"\']*)["\'](,\\s*({[\\s\\S]*?})){0,1}\\s*\\)+');
+  var includeRegExp = new RegExp(prefix + 'include\\s*\\([^)"\']*["\']([^"\']*)["\'](,\\s*({[\\s\\S]*?})){0,1}\\s*\\)+' + suffix);
 
   function fileInclude(file, enc, cb) {
     if (file.isNull()) {
@@ -52,13 +54,13 @@ module.exports = function(options) {
    */
   function stripCommentedIncludes(content) {
     // remove single line html comments that use the format: <!-- @@include() -->
-    var regex = new RegExp('<\!--(.*)' + prefix + 'include([\\s\\S]*?)-->', 'g');
+    var regex = new RegExp('<\!--(.*)' + prefix + 'include([\\s\\S]*?)' + suffix + '-->', 'g');
     return content.replace(regex, '');
   }
 
   function parseConditionalIncludes(content, variables) {
     // parse @@if (something) { include('...') }
-    var regexp = new RegExp(prefix + 'if.*\\{[^{}]*\\}\\s*'),
+    var regexp = new RegExp(prefix + 'if.*\\{[^{}]*\\}\\s*' + suffix),
       matches = regexp.exec(content),
       included = false;
 


### PR DESCRIPTION
Hello. I would like to use gulp-file-include to break up our json files which are very large.
It works fine, but I want to be able to support this case:
`{key: @@include('a.json')}`
But this is not valid json. However this would be valid json:
`{key: "@@include('a.json')"}`

I have tried the following test case to see that it works.
my settings:
```
.pipe(fileinclude({
	prefix: '"@@',
	suffix: '@@"',
	basepath: '@file'
}))
```

index.json:
```
{
	"start": 1,
	"firstObject": "@@include('./partial1.json')@@",
	"ifTrue": "@@if (1+1 === 2) {"@@include('./partial3.json')@@"}@@",
	"ifFalse": {"@@if (1+1 === 1) {"@@include('./partial3.json')@@"}@@"},
	"someObject": "@@include('./partial1.json')@@",
	"end": 2
}
```
partial1.json:
```
{
		"fromPartial": "true",
		"nestedPartial": {
			"someObject": "@@include('./partial2.json')@@"
		},
		"nestedPartial2": {
			"someObject": "@@include('./partial2.json')@@"
		}
```
partial2.json:
```
{
				"fromPartial2": "true",
				"itWorked": "hurray"
			}
```
partial3.json:
```
"Content of partial 3"
```

Resulting json:
```
{
	"start": 1,
	"firstObject": {
		"fromPartial": "true",
		"nestedPartial": {
			"someObject": {
				"fromPartial2": "true",
				"itWorked": "hurray"
			}
		},
		"nestedPartial2": {
			"someObject": {
				"fromPartial2": "true",
				"itWorked": "hurray"
			}
		},
	"ifTrue": "Content of partial 3",
	"ifFalse": {},
	"someObject": {
		"fromPartial": "true",
		"nestedPartial": {
			"someObject": {
				"fromPartial2": "true",
				"itWorked": "hurray"
			}
		},
		"nestedPartial2": {
			"someObject": {
				"fromPartial2": "true",
				"itWorked": "hurray"
			}
		},
	"end": 2
}
```
If you don't like this solution I would appreciate that you update gulp-file-include to work with json. I'm sure you would do a better job at this than I did.
Thanks in advance.
/Jonas