### PR TITLE
applyFilters method inspects match for options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,8 +149,12 @@ module.exports = function(opts) {
     // compose them together into one function
     var filter = filterlist.reduce(compose);
 
+    // check match for filter options object
+    var options = match.match('{([^}]*)}') || ["{}"];
+    options = JSON.parse(options[0]);
+
     // and apply the composed function to the stringified content
-    return filter(String(includeContent));
+    return filter(String(includeContent), options);
   }
 };
 


### PR DESCRIPTION
The applyFilters method will now check the match for a json object
and, if found, pass it as a secont paramenter in your filter hander.
Useful for stating how you want your filter to address a given include
in the context of the @@include statement itself.
