### PR TITLE
improved error messages for "for" and "if" statements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,18 +105,27 @@ module.exports = function(opts) {
     });
 
     function conditionalHandler(inst) {
-      // jshint ignore: start
-      var condition = new Function('var context = this; with (context) { return ' + inst.args + '; }').call(data);
-      // jshint ignore: end
+      try {
+        // jshint ignore: start
+        var condition = new Function('var context = this; with (context) { return ' + inst.args + '; }').call(data);
+        // jshint ignore: end
+      } catch (error) {
+        throw new Error(error.message + ': ' + inst.args);
+      }
 
       return condition ? inst.body : '';
     }
 
     function forHandler(inst) {
-      var condition = 'var context = this; with (context) { var result=""; for' + inst.args + ' { result+=`' + inst.body + '`; } return result; }';
+      var forLoop = 'for' + inst.args + ' { result+=`' + inst.body + '`; }';
+      var condition = 'var context = this; with (context) { var result=""; ' + forLoop + ' return result; }';
+      try {
       // jshint ignore: start
       var result = new Function(condition).call(data);
       // jshint ignore: end
+      } catch (error) {
+        throw new Error(error.message + ': ' + forLoop);
+      }
 
       return result;
     }

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fileIncludePlugin = require('..');
+const gutil = require('gulp-util');
+const should = require('should');
+const fs = require('fs');
+
+describe('## error', () => {
+
+  it('# if statement', done => {
+    var file = new gutil.File({
+      path: 'test/fixtures-error/if.html',
+      contents: fs.readFileSync('test/fixtures-error/if.html')
+    });
+
+    var stream = fileIncludePlugin({
+      prefix: '@@',
+      basepath: '@root'
+    });
+    stream.on('error', error => {
+      error.message.should.equal('invalid is not defined:  (invalid === true) ');
+      done();
+    });
+    stream.write(file);
+    stream.end();
+  });
+
+  it('# for statement', done => {
+    var file = new gutil.File({
+      path: 'test/fixtures-error/if.html',
+      contents: fs.readFileSync('test/fixtures-error/for.html')
+    });
+
+    var stream = fileIncludePlugin({
+      prefix: '@@',
+      basepath: '@root'
+    });
+    stream.on('error', error => {
+      error.message.should.equal('invalid is not defined: for (var i = 0; i < invalid.length; i++)  { result+=`\n  <label>`+invalid[i]+`</label>\n  `; }');
+      done();
+    });
+    stream.write(file);
+    stream.end();
+  });
+
+});

--- a/test/fixtures-error/for.html
+++ b/test/fixtures-error/for.html
@@ -1,0 +1,3 @@
+@@for (var i = 0; i < invalid.length; i++) {
+  <label>`+invalid[i]+`</label>
+  }

--- a/test/fixtures-error/if.html
+++ b/test/fixtures-error/if.html
@@ -1,0 +1,3 @@
+@@if (invalid === true) {
+  <h1>a</h1>
+}


### PR DESCRIPTION
Instead of the native JS error only the error message now also contains some context:

Before:
```
 Invalid or unexpected token
```

Now:
```
 Invalid or unexpected token:  (@@someVar=== true)
```