### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ const replaceVariable = require('./replace-variable')
 const concat = require('concat-stream')
 const setIndent = require('./indent')
 const through = require('through2')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
+const PluginError = require('plugin-error')
 const extend = require('extend')
 const path = require('path')
 const fs = require('fs')
@@ -46,7 +47,7 @@ module.exports = function(opts) {
           data = include(file, String(data))
           cb(null, data)
         } catch (e) {
-          cb(new gutil.PluginError('gulp-file-include', e.message))
+          cb(new PluginError('gulp-file-include', e.message))
         }
       }))
     } else if (file.isBuffer()) {
@@ -54,7 +55,7 @@ module.exports = function(opts) {
         file = include(file, String(file.contents))
         cb(null, file)
       } catch (e) {
-        cb(new gutil.PluginError('gulp-file-include', e.message))
+        cb(new PluginError('gulp-file-include', e.message))
       }
     }
   }
@@ -150,7 +151,7 @@ module.exports = function(opts) {
           includeContent = applyFilters(includeContent, args.input)
         }
 
-        var recFile = new gutil.File({
+        var recFile = new Vinyl({
           cwd: process.cwd(),
           base: file.base,
           path: includePath,
@@ -205,7 +206,7 @@ module.exports = function(opts) {
             includeContent = applyFilters(includeContent, args.input)
           }
 
-          var recFile = new gutil.File({
+          var recFile = new Vinyl({
             cwd: process.cwd(),
             base: file.base,
             path: includePath,

--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "concat-stream": "^1.6.0",
     "extend": "^3.0.1",
     "flatnest": "^1.0.0",
-    "gulp-util": "^3.0.8",
-    "through2": "^2.0.3"
+    "plugin-error": "^0.1.2",
+    "through2": "^2.0.3",
+    "vinyl": "^2.1.0"
   },
   "eslintConfig": {
     "extends": [

--- a/test/edge-case.js
+++ b/test/edge-case.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
 describe('## gulp-file-include', () => {
   describe('# edge cases', () => {
     it('should escape included content to avoid recursive includes', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-edge-case/index.html',
         contents: fs.createReadStream('test/fixtures-edge-case/index.html')
       })
@@ -28,7 +28,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('should work without trailing newline', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-edge-case/without-trailing-newline.txt',
         contents: fs.createReadStream('test/fixtures-edge-case/without-trailing-newline.txt')
       })
@@ -48,7 +48,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('should skip commented includes', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-edge-case/commented-inclusion.html',
         contents: fs.createReadStream('test/fixtures-edge-case/commented-inclusion.html')
       })
@@ -68,7 +68,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('should give an error on recursive includes', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-edge-case/recursion.html',
         contents: fs.createReadStream('test/fixtures-edge-case/recursion.html')
       })
@@ -85,7 +85,7 @@ describe('## gulp-file-include', () => {
     })
 
     // it('should give an error on circular recursive includes', function(done) {
-    //   var file = new gutil.File({
+    //   var file = new Vinyl({
     //     path: 'test/fixtures-edge-case/a.html',
     //     contents: fs.createReadStream('test/fixtures-edge-case/a.html')
     //   });

--- a/test/error.js
+++ b/test/error.js
@@ -3,6 +3,7 @@
 const fileIncludePlugin = require('..')
 const Vinyl = require('vinyl')
 const fs = require('fs')
+const os = require('os')
 
 require('should')
 
@@ -36,7 +37,7 @@ describe('## error', () => {
       basepath: '@root'
     })
     stream.on('error', error => {
-      error.message.should.equal('invalid is not defined: for (var i = 0; i < invalid.length; i++)  { result+=`\n  <label>`+invalid[i]+`</label>\n  `; }')
+      error.message.should.equal('invalid is not defined: for (var i = 0; i < invalid.length; i++)  { result+=`' + os.EOL + '  <label>`+invalid[i]+`</label>' + os.EOL + '  `; }')
       done()
     })
     stream.write(file)

--- a/test/error.js
+++ b/test/error.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const fs = require('fs')
 
 require('should')
 
 describe('## error', () => {
   it('# if statement', done => {
-    var file = new gutil.File({
+    var file = new Vinyl({
       path: 'test/fixtures-error/if.html',
       contents: fs.readFileSync('test/fixtures-error/if.html')
     })
@@ -26,7 +26,7 @@ describe('## error', () => {
   })
 
   it('# for statement', done => {
-    var file = new gutil.File({
+    var file = new Vinyl({
       path: 'test/fixtures-error/if.html',
       contents: fs.readFileSync('test/fixtures-error/for.html')
     })

--- a/test/filters.js
+++ b/test/filters.js
@@ -2,7 +2,7 @@
 
 const fileIncludePlugin = require('..')
 const markdown = require('markdown')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
@@ -11,7 +11,7 @@ describe('## gulp-file-include', () => {
 
   describe('# options - filters', () => {
     it('file - filters: markdown', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-markdown.html',
         contents: fs.readFileSync('test/fixtures/index-markdown.html')
       })
@@ -35,7 +35,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - filters: markdown', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-markdown.html',
         contents: fs.createReadStream('test/fixtures/index-markdown.html')
       })
@@ -59,7 +59,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('file - filters: markdown & rot13', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-markdown-rot13.html',
         contents: fs.readFileSync('test/fixtures/index-markdown-rot13.html')
       })
@@ -84,7 +84,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - filters: markdown & rot13', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-markdown-rot13.html',
         contents: fs.createReadStream('test/fixtures/index-markdown-rot13.html')
       })
@@ -109,7 +109,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('file - filters: custom filter handler options', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-handler-options.html',
         contents: fs.createReadStream('test/fixtures/index-handler-options.html')
       })

--- a/test/flatten.js
+++ b/test/flatten.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
@@ -10,7 +10,7 @@ describe('## gulp-file-include', () => {
 
   describe('# flatten variables', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-flatten/index.html',
         contents: fs.readFileSync('test/fixtures-flatten/index.html')
       })
@@ -36,7 +36,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-flatten/index.html',
         contents: fs.createReadStream('test/fixtures-flatten/index.html')
       })

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
@@ -14,7 +14,7 @@ describe('## gulp-file-include', () => {
 
   describe('# default', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-01.html',
         contents: fs.readFileSync('test/fixtures/index-01.html')
       })
@@ -33,7 +33,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-01.html',
         contents: fs.createReadStream('test/fixtures/index-01.html')
       })
@@ -54,7 +54,7 @@ describe('## gulp-file-include', () => {
 
   describe('# options - basepath', () => {
     it('file - basepath: @file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-01.html',
         contents: fs.readFileSync('test/fixtures/index-01.html')
       })
@@ -75,7 +75,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - basepath: @file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-01.html',
         contents: fs.createReadStream('test/fixtures/index-01.html')
       })
@@ -96,7 +96,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('file - basepath: @root', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-03.html',
         contents: fs.readFileSync('test/fixtures/index-03.html')
       })
@@ -117,7 +117,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - basepath: @root', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-03.html',
         contents: fs.createReadStream('test/fixtures/index-03.html')
       })
@@ -138,7 +138,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('file - basepath: dir', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-02.html',
         contents: fs.readFileSync('test/fixtures/index-02.html')
       })
@@ -159,7 +159,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - basepath: dir', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-02.html',
         contents: fs.createReadStream('test/fixtures/index-02.html')
       })
@@ -182,7 +182,7 @@ describe('## gulp-file-include', () => {
 
   describe('# options - prefix, basepath', () => {
     it('file - basepath: @file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-01.html',
         contents: fs.readFileSync('test/fixtures/index-01.html')
       })
@@ -204,7 +204,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - basepath: @file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-01.html',
         contents: fs.createReadStream('test/fixtures/index-01.html')
       })
@@ -226,7 +226,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('file - basepath: @root', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-03.html',
         contents: fs.readFileSync('test/fixtures/index-03.html')
       })
@@ -248,7 +248,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - basepath: @root', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-03.html',
         contents: fs.createReadStream('test/fixtures/index-03.html')
       })
@@ -270,7 +270,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('file - basepath: dir', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-02.html',
         contents: fs.readFileSync('test/fixtures/index-02.html')
       })
@@ -292,7 +292,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - basepath: dir', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-02.html',
         contents: fs.createReadStream('test/fixtures/index-02.html')
       })
@@ -316,7 +316,7 @@ describe('## gulp-file-include', () => {
 
   describe('# options - suffix', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-suffix/index.html',
         contents: fs.readFileSync('test/fixtures-suffix/index.html')
       })
@@ -338,7 +338,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-suffix/index.html',
         contents: fs.createReadStream('test/fixtures-suffix/index.html')
       })
@@ -362,7 +362,7 @@ describe('## gulp-file-include', () => {
 
   describe('# vars - same key prefix', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/sameprefix.html',
         contents: fs.readFileSync('test/fixtures/sameprefix.html')
       })
@@ -381,7 +381,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/sameprefix.html',
         contents: fs.createReadStream('test/fixtures/sameprefix.html')
       })
@@ -402,7 +402,7 @@ describe('## gulp-file-include', () => {
 
   describe('# aggressive regex', () => {
     it('file - basepath: @root', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-04.js',
         contents: fs.readFileSync('test/fixtures/index-04.js')
       })
@@ -423,7 +423,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream - basepath: @root', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-04.js',
         contents: fs.createReadStream('test/fixtures/index-04.js')
       })
@@ -446,7 +446,7 @@ describe('## gulp-file-include', () => {
 
   describe('# for statement', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-05.html',
         contents: fs.readFileSync('test/fixtures/index-05.html')
       })
@@ -465,7 +465,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures/index-05.html',
         contents: fs.createReadStream('test/fixtures/index-05.html')
       })

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
@@ -10,7 +10,7 @@ describe('## gulp-file-include', () => {
 
   describe('# nested arguments', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-nested/index.html',
         contents: fs.readFileSync('test/fixtures-nested/index.html')
       })
@@ -29,7 +29,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-nested/index.html',
         contents: fs.createReadStream('test/fixtures-nested/index.html')
       })

--- a/test/plugin-indent.js
+++ b/test/plugin-indent.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
@@ -10,7 +10,7 @@ describe('## gulp-file-include', () => {
 
   describe('# indent', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-indent/index.html',
         contents: fs.readFileSync('test/fixtures-indent/index.html')
       })
@@ -32,7 +32,7 @@ describe('## gulp-file-include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-indent/index.html',
         contents: fs.createReadStream('test/fixtures-indent/index.html')
       })

--- a/test/recursion.js
+++ b/test/recursion.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
@@ -10,7 +10,7 @@ describe('## recursion include', () => {
 
   describe('# basepath: @file', () => {
     it('file', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-recursion/index.txt',
         contents: fs.readFileSync('test/fixtures-recursion/index.txt')
       })
@@ -31,7 +31,7 @@ describe('## recursion include', () => {
     })
 
     it('stream', done => {
-      var file = new gutil.File({
+      var file = new Vinyl({
         path: 'test/fixtures-recursion/index.txt',
         contents: fs.createReadStream('test/fixtures-recursion/index.txt')
       })

--- a/test/webroot-variable.js
+++ b/test/webroot-variable.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fileIncludePlugin = require('..')
-const gutil = require('gulp-util')
+const Vinyl = require('vinyl')
 const should = require('should')
 const fs = require('fs')
 
@@ -9,7 +9,7 @@ describe('## built-in webRoot variable', () => {
   it('# regular usage and includes', done => {
     var result = fs.readFileSync('test/fixtures-webroot-variable/result.html', 'utf8')
     var path = 'test/fixtures-webroot-variable/index.html'
-    var file = new gutil.File({ path: path, contents: fs.createReadStream(path) })
+    var file = new Vinyl({ path: path, contents: fs.createReadStream(path) })
 
     var stream = fileIncludePlugin()
     stream.on('data', newFile => {
@@ -27,7 +27,7 @@ describe('## built-in webRoot variable', () => {
   it('# nested folder', done => {
     var result = fs.readFileSync('test/fixtures-webroot-variable/sub/result.html', 'utf8')
     var path = 'test/fixtures-webroot-variable/sub/index.html'
-    var file = new gutil.File({ path: path, contents: fs.createReadStream(path) })
+    var file = new Vinyl({ path: path, contents: fs.createReadStream(path) })
 
     var stream = fileIncludePlugin()
     stream.on('data', newFile => {


### PR DESCRIPTION
Closes #150.

In passing, I made a test compatible with Windows by replacing hardcoded `\n` newlines with `os.EOL`.